### PR TITLE
Added initialize_model_params! to scp_mao+scp_trajopt and added csi_s…

### DIFF
--- a/src/robot/car.jl
+++ b/src/robot/car.jl
@@ -4,5 +4,4 @@ mutable struct Car <: Robot
   btCollisionObject
 end
 # Necessary - Avoids zero distance when calling Bullet
-#Car() = Car(BulletCollision.convex_hull([zeros(3)]))
 Car() = Car(BulletCollision.sphere(SVector{3}(zeros(Float32,3)), 0.001))

--- a/src/scp/scp_gusto.jl
+++ b/src/scp/scp_gusto.jl
@@ -151,6 +151,10 @@ function add_constraints_gusto_cvx(SCPV::SCPVariables, traj_prev::Trajectory, SC
 		constraints += f(SCPV, traj_prev, SCPP, k, i) == 0.
 	end
 
+  for (f, k, i) in SCPC.convex_state_goal_ineq
+		constraints += f(SCPV, traj_prev, SCPP, k, i) <= 0.
+	end
+
 	for (f, k, i) in SCPC.convex_control_ineq
 		constraints += f(SCPV, traj_prev, SCPP, k, i) <= 0.
 	end

--- a/src/types.jl
+++ b/src/types.jl
@@ -124,6 +124,7 @@ mutable struct SCPConstraints
 	dynamics::Vector
 	convex_state_eq::Vector
 	convex_state_ineq::Vector
+	convex_state_goal_ineq::Vector
 	nonconvex_state_eq::Vector
 	nonconvex_state_ineq::Vector
 	nonconvex_state_convexified_eq::Vector
@@ -135,7 +136,7 @@ mutable struct SCPConstraints
 	state_trust_region_ineq::Vector
 	control_trust_region_ineq::Vector
 end
-SCPConstraints() = SCPConstraints(([] for i in 1:11)...)
+SCPConstraints() = SCPConstraints(([] for i in 1:12)...)
 
 mutable struct ShootingProblem{R<:Robot, D<:DynamicsModel, E<:Environment}
 	PD::ProblemDefinition{R,D,E}


### PR DESCRIPTION
- Added initialize_model_params! to scp_mao and scp_trajopt as they're in a broken state currently.
- Added csi_state_goal_inequality for handling goal region-type constraints.